### PR TITLE
fix: Trusted publishing and cargo-binstall support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ exclude = [".assets/*", ".cargo/*", ".github/*", "Wargo.toml"]
 
 default-run = "wargo"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-{ version }/{ name }-{ target }"
+pkg-fmt = "tgz"
+
 [lib]
 name = "wargo_lib"
 


### PR DESCRIPTION
Closes #270